### PR TITLE
Remove /usr/lib/node_modules for Node.js 8.x

### DIFF
--- a/8/nodejs-libpath.patch
+++ b/8/nodejs-libpath.patch
@@ -7,7 +7,7 @@ Index: node-v7.7.4/lib/module.js
      prefixDir = path.resolve(process.execPath, '..', '..');
    }
 -  var paths = [path.resolve(prefixDir, 'lib', 'node')];
-+  var paths = ['/usr/lib/node_modules', '/usr/lib/node'];
++  var paths = ['/usr/lib/node'];
  
    if (homeDir) {
      paths.unshift(path.resolve(homeDir, '.node_libraries'));


### PR DESCRIPTION
This is not documented behaviour from upstream and has only been included because of a patch in previous versions that included this path for not much reason.