### PR TITLE
Fix typo in addon-rpm.gypi patch

### DIFF
--- a/common/node-gyp-addon-gypi.patch
+++ b/common/node-gyp-addon-gypi.patch
@@ -71,7 +71,7 @@ Index: node-v6.9.0/deps/npm/node_modules/node-gyp/lib/configure.js
      // this logic ported from the old `gyp_addon` python file
      var gyp_script = path.resolve(__dirname, '..', 'gyp', 'gyp_main.py')
 -    var addon_gypi = path.resolve(__dirname, '..', 'addon.gypi')
-+    var addon_gypi_file = gyp.opts.target || gyp.opts.nodeDir ? 'addon.gypi' : 'addon-rpm.gypi'
++    var addon_gypi_file = gyp.opts.target || gyp.opts.nodedir ? 'addon.gypi' : 'addon-rpm.gypi'
 +    var addon_gypi = path.resolve(__dirname, '..', addon_gypi_file)
      var common_gypi = path.resolve(nodeDir, 'include/node/common.gypi')
      fs.stat(common_gypi, function (err, stat) {


### PR DESCRIPTION
- Definition: https://github.com/nodejs/node-gyp/blob/72afdd62cdb960d92b110e713091fb4efd870963/lib/node-gyp.js#L85
- Example of usage: https://github.com/nodejs/node-gyp/blob/72afdd62cdb960d92b110e713091fb4efd870963/lib/install.js#L62