### PR TITLE
Explicitly require OpenSSL 1.0 for build

### DIFF
--- a/4/nodejs4.changes
+++ b/4/nodejs4.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 29 01:41:56 UTC 2017 - qantas94heavy@gmail.com
+
+- Change BuildRequires from openssl-devel to libopenssl-1_0_0-devel
+  due to Tumbleweed/Leap 15 change to OpenSSL 1.1.0 as default
+
+-------------------------------------------------------------------
 Thu Nov 16 13:16:25 UTC 2017 - adam.majer@suse.de
 
 - Update nodejs.keyring based on current Release Team as found on

--- a/6/nodejs6.changes
+++ b/6/nodejs6.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 29 01:41:56 UTC 2017 - qantas94heavy@gmail.com
+
+- Change BuildRequires from openssl-devel to libopenssl-1_0_0-devel
+  due to Tumbleweed/Leap 15 change to OpenSSL 1.1.0 as default
+
+-------------------------------------------------------------------
 Thu Nov 16 13:16:25 UTC 2017 - adam.majer@suse.de
 
 - Update nodejs.keyring based on current Release Team as found on

--- a/8/8334.diff
+++ b/8/8334.diff
@@ -1,3 +1,0 @@
-Empty patch. Placeholder must exist as long as same patch
-for older Node codestreams exist.
-

--- a/8/nodejs8.changes
+++ b/8/nodejs8.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 29 01:41:56 UTC 2017 - qantas94heavy@gmail.com
+
+- Change BuildRequires from openssl-devel to libopenssl-1_0_0-devel
+  due to Tumbleweed/Leap 15 change to OpenSSL 1.1.0 as default
+
+-------------------------------------------------------------------
 Thu Nov 16 13:16:25 UTC 2017 - adam.majer@suse.de
 
 - Update nodejs.keyring based on current Release Team as found on

--- a/9/8334.diff
+++ b/9/8334.diff
@@ -1,3 +1,0 @@
-Empty patch. Placeholder must exist as long as same patch
-for older Node codestreams exist.
-

--- a/9/nodejs9.changes
+++ b/9/nodejs9.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Nov 29 01:41:56 UTC 2017 - qantas94heavy@gmail.com
+
+- Change BuildRequires from openssl-devel to libopenssl-1_0_0-devel
+  due to Tumbleweed/Leap 15 change to OpenSSL 1.1.0 as default
+
+-------------------------------------------------------------------
 Thu Nov 16 13:16:25 UTC 2017 - adam.majer@suse.de
 
 - Update nodejs.keyring based on current Release Team as found on

--- a/common/8334.diff
+++ b/common/8334.diff
@@ -1,3 +1,2 @@
 Empty patch. Placeholder must exist as long as same patch
 for older Node codestreams exist.
-

--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -154,7 +154,11 @@ BuildRequires:  xz
 BuildRequires:  zlib-devel
 
 %if ! %{with intree_openssl}
+%if 0%{?suse_version} >= 1330
+BuildRequires:  libopenssl-1_0_0-devel
+%else
 BuildRequires:  openssl-devel >= 1.0.2
+%endif
 %endif
 
 %if ! %{with intree_cares}


### PR DESCRIPTION
This is just for the time being until upstream OpenSSL 1.1 support is a bit more stable/tested.