### PR TITLE
Build Leap 42.3 with gcc7, but SLE12 SP3 with gcc6

### DIFF
--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -148,7 +148,7 @@ BuildRequires:   gcc5-c++
 %define cc_exec  gcc-5
 %define cpp_exec g++-5
 %else
-%if 0%{?sle_version} <= 120200
+%if 0%{?sle_version} <= 120200 || (0%{?sle_version} == 120300 && !0%{?is_opensuse})
 BuildRequires:   gcc6-c++
 %define cc_exec  gcc-6
 %define cpp_exec g++-6
@@ -156,7 +156,7 @@ BuildRequires:   gcc6-c++
 BuildRequires:   gcc7-c++
 %define cc_exec  gcc-7
 %define cpp_exec g++-7
-%endif # SLE 12 <= SP2
+%endif # SLE 12 <= SP2 and SLE 12 SP3 but not Leap 42.3
 %endif # SLE 12 < SP1
 %endif # node >= 8 and sle == 12
 


### PR DESCRIPTION
The previous commit "Build Leap 42.3 with gcc7" made nodejs8 build with Leap 42.3, but SLE12 SP3 build broke.

With this change it will build with both SLE12 SP3 (using gcc6) and Build Leap 42.3 (using gcc7).