### PR TITLE
Add LICENSE file for nodejs-common package

### DIFF
--- a/nodejs-common/LICENSE
+++ b/nodejs-common/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2018 SUSE LINUX GmbH, Nuernberg, Germany.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/nodejs-common/nodejs-common.spec
+++ b/nodejs-common/nodejs-common.spec
@@ -32,6 +32,7 @@ Summary:        Common files for the NodeJS ecosystem
 Url:            https://github.com/AdamMajer/nodejs-packaging
 Group:          Development/Languages/NodeJS
 Source1:        node
+Source2:        LICENSE
 Requires:       nodejs
 Conflicts:      nodejs4 < 4.8.4
 Conflicts:      nodejs6 < 6.11.1
@@ -47,6 +48,7 @@ while retaining the same codestream version.
 
 %prep
 %build
+cp %{S:2} .
 %install
 install -D -m 0755 %{S:1} %{buildroot}%{_bindir}/node
 ln -s node %{buildroot}%{_bindir}/npm
@@ -57,6 +59,7 @@ ln -s node %{buildroot}%{_bindir}/npx
 %{_bindir}/node
 %{_bindir}/npm
 %{_bindir}/npx
+%license LICENSE
 
 %changelog
 


### PR DESCRIPTION
Even nodejs-common is a minimalist package, we'd like to ship nodejs-common with it's own license file. I hope this makes sense.

* Added LICENSE file
* Updated spec to make use of the %license macro