### PR TITLE
Normalize shebangs instead of dropping

### DIFF
--- a/8/env_shebang.patch
+++ b/8/env_shebang.patch
@@ -8,24 +8,6 @@ Index: node-v8.11.2/deps/npm/bin/npm-cli.js
  ;(function () { // wrapper in case we're in module_context mode
    // windows: running "npm blah" in this folder will invoke WSH, not node.
    /*global WScript*/
-Index: node-v8.11.2/deps/npm/bin/npx
-===================================================================
---- node-v8.11.2.orig/deps/npm/bin/npx
-+++ node-v8.11.2/deps/npm/bin/npx
-@@ -1,4 +1,3 @@
--#!/bin/sh
- (set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
- 
- basedir=`dirname "$0"`
-Index: node-v8.11.2/deps/npm/bin/npm
-===================================================================
---- node-v8.11.2.orig/deps/npm/bin/npm
-+++ node-v8.11.2/deps/npm/bin/npm
-@@ -1,4 +1,3 @@
--#!/bin/sh
- (set -o igncr) 2>/dev/null && set -o igncr; # cygwin encoding fix
- 
- basedir=`dirname "$0"`
 Index: node-v8.11.2/deps/npm/bin/npx-cli.js
 ===================================================================
 --- node-v8.11.2.orig/deps/npm/bin/npx-cli.js
@@ -36,361 +18,24 @@ Index: node-v8.11.2/deps/npm/bin/npx-cli.js
  
  const npx = require('libnpx')
  const path = require('path')
-Index: node-v8.11.2/deps/npm/node_modules/mkdirp/bin/cmd.js
+Index: node-v8.11.2/deps/npm/lib/utils/completion.sh
 ===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/mkdirp/bin/cmd.js
-+++ node-v8.11.2/deps/npm/node_modules/mkdirp/bin/cmd.js
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- var mkdirp = require('../');
- var minimist = require('minimist');
- var fs = require('fs');
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/gyp
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/gyp
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/gyp
+--- node-v8.11.2.orig/deps/npm/lib/utils/completion.sh
++++ node-v8.11.2/deps/npm/lib/utils/completion.sh
 @@ -1,4 +1,3 @@
--#!/bin/sh
- # Copyright 2013 The Chromium Authors. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/gyp_main.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/gyp_main.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/gyp_main.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2009 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/gyptest.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/gyptest.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/gyptest.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/__init__.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/flock_tool.py
-@@ -1,4 +1,3 @@
--#!/usr/bin/env python
- # Copyright (c) 2011 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/mac_tool.py
-@@ -1,4 +1,3 @@
--#!/usr/bin/env python
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/pylib/gyp/win_tool.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/samples/samples
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/samples/samples
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/samples/samples
-@@ -1,5 +1,3 @@
--#!/usr/bin/python
--
- # Copyright (c) 2009 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/setup.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/setup.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/setup.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2009 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/graphviz.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/tools/graphviz.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/graphviz.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2011 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/pretty_gyp.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/pretty_sln.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/tools/pretty_vcproj.py
-@@ -1,5 +1,3 @@
--#!/usr/bin/env python
--
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/node_modules/nopt/bin/nopt.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/node_modules/nopt/bin/nopt.js
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/node_modules/nopt/bin/nopt.js
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- var nopt = require("../lib/nopt")
-   , path = require("path")
-   , types = { num: Number
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/node_modules/semver/bin/semver
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/node_modules/semver/bin/semver
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/node_modules/semver/bin/semver
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- // Standalone semver comparison program.
- // Exits successfully and prints matching version(s) if
- // any supplied version is valid and passes all tests.
-Index: node-v8.11.2/deps/npm/node_modules/nopt/bin/nopt.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/nopt/bin/nopt.js
-+++ node-v8.11.2/deps/npm/node_modules/nopt/bin/nopt.js
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- var nopt = require("../lib/nopt")
-   , path = require("path")
-   , types = { num: Number
-Index: node-v8.11.2/deps/npm/node_modules/opener/opener.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/opener/opener.js
-+++ node-v8.11.2/deps/npm/node_modules/opener/opener.js
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- "use strict";
- 
- var childProcess = require("child_process");
-Index: node-v8.11.2/deps/npm/node_modules/qrcode-terminal/bin/qrcode-terminal.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/qrcode-terminal/bin/qrcode-terminal.js
-+++ node-v8.11.2/deps/npm/node_modules/qrcode-terminal/bin/qrcode-terminal.js
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- /*!
-  * Module dependencies.
-  */
-Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/info
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/info
-+++ node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/info
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- 'use strict';
- 
- var fs = require('fs');
-Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/prepare-tests
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/prepare-tests
-+++ node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/prepare-tests
-@@ -1,5 +1,3 @@
--#!/usr/bin/env sh
--
- set -e
- 
- mkdir -p .browser
+-#!/bin/bash
+ ###-begin-npm-completion-###
+ #
+ # npm command completion script
 Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/travis-gh-pages
 ===================================================================
 --- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/travis-gh-pages
 +++ node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/travis-gh-pages
-@@ -1,5 +1,3 @@
+@@ -1,4 +1,4 @@
 -#!/usr/bin/env bash
--
++#!/bin/bash
+ 
  set -e
- 
- if [[ "$TRAVIS_BRANCH" == "master" && "$TRAVIS_PULL_REQUEST" == "false" && $TRAVIS_JOB_NUMBER =~ ".3" ]]; then
-Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-conv
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-conv
-+++ node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-conv
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- // -*- mode: js -*-
- // vim: set filetype=javascript :
- // Copyright 2015 Joyent, Inc.  All rights reserved.
-Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-sign
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-sign
-+++ node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-sign
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- // -*- mode: js -*-
- // vim: set filetype=javascript :
- // Copyright 2015 Joyent, Inc.  All rights reserved.
-Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-verify
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-verify
-+++ node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-verify
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- // -*- mode: js -*-
- // vim: set filetype=javascript :
- // Copyright 2015 Joyent, Inc.  All rights reserved.
-Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash/etc/dashdash.bash_completion.in
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash/etc/dashdash.bash_completion.in
-+++ node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash/etc/dashdash.bash_completion.in
-@@ -1,4 +1,3 @@
--#!/bin/bash
- #
- # Bash completion generated for '{{name}}' at {{date}}.
- #
-@@ -386,4 +385,4 @@ fi
- ##
- ##     cp FILE > ~/.{{name}}.completion
- ##     echo "source ~/.{{name}}.completion" >> ~/.bashrc
--##
-\ No newline at end of file
-+##
-Index: node-v8.11.2/deps/npm/node_modules/rimraf/bin.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/rimraf/bin.js
-+++ node-v8.11.2/deps/npm/node_modules/rimraf/bin.js
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- var rimraf = require('./')
- 
- var help = false
-Index: node-v8.11.2/deps/npm/node_modules/semver/bin/semver
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/semver/bin/semver
-+++ node-v8.11.2/deps/npm/node_modules/semver/bin/semver
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- // Standalone semver comparison program.
- // Exits successfully and prints matching version(s) if
- // any supplied version is valid and passes all tests.
-Index: node-v8.11.2/deps/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/index.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/index.js
-+++ node-v8.11.2/deps/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-auth-token/node_modules/rc/index.js
-@@ -1,4 +1,3 @@
--#! /usr/bin/env node
- var cc   = require('./lib/utils')
- var join = require('path').join
- var deepExtend = require('deep-extend')
-Index: node-v8.11.2/deps/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/index.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/index.js
-+++ node-v8.11.2/deps/npm/node_modules/update-notifier/node_modules/latest-version/node_modules/package-json/node_modules/registry-url/node_modules/rc/index.js
-@@ -1,4 +1,3 @@
--#! /usr/bin/env node
- var cc   = require('./lib/utils')
- var join = require('path').join
- var deepExtend = require('deep-extend')
-Index: node-v8.11.2/deps/npm/node_modules/uuid/bin/uuid
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/uuid/bin/uuid
-+++ node-v8.11.2/deps/npm/node_modules/uuid/bin/uuid
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- var assert = require('assert');
- 
- function usage() {
-Index: node-v8.11.2/deps/npm/node_modules/which/bin/which
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/which/bin/which
-+++ node-v8.11.2/deps/npm/node_modules/which/bin/which
-@@ -1,4 +1,3 @@
--#!/usr/bin/env node
- var which = require("../")
- if (process.argv.length < 3)
-   usage()
-Index: node-v8.11.2/deps/npm/node_modules/worker-farm/node_modules/errno/build.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/worker-farm/node_modules/errno/build.js
-+++ node-v8.11.2/deps/npm/node_modules/worker-farm/node_modules/errno/build.js
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- var request   = require('request')
-   , fs        = require('fs')
- 
-@@ -40,4 +38,4 @@ request(uvheadloc, function (err, respon
-   out += '\nmodule.exports.custom = require("./custom")(module.exports)\n'
- 
-   fs.writeFile('errno.js', out)
--})
-\ No newline at end of file
-+})
-Index: node-v8.11.2/deps/npm/node_modules/worker-farm/node_modules/errno/cli.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/worker-farm/node_modules/errno/cli.js
-+++ node-v8.11.2/deps/npm/node_modules/worker-farm/node_modules/errno/cli.js
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- var errno = require('./')
-   , arg   = process.argv[2]
-   , data, code
-@@ -17,4 +15,4 @@ if (data)
- else {
-   console.error('No such errno/code: "' + arg + '"')
-   process.exit(1)
--}
-\ No newline at end of file
-+}
-Index: node-v8.11.2/deps/npm/node_modules/worker-farm/node_modules/errno/test.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/worker-farm/node_modules/errno/test.js
-+++ node-v8.11.2/deps/npm/node_modules/worker-farm/node_modules/errno/test.js
-@@ -1,5 +1,3 @@
--#!/usr/bin/env node
--
- var test  = require('tape')
-   , errno = require('./')
  
 Index: node-v8.11.2/deps/npm/bin/node-gyp-bin/node-gyp
 ===================================================================
@@ -402,16 +47,6 @@ Index: node-v8.11.2/deps/npm/bin/node-gyp-bin/node-gyp
  if [ "x$npm_config_node_gyp" = "x" ]; then
    node "`dirname "$0"`/../../node_modules/node-gyp/bin/node-gyp.js" "$@"
  else
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/bin/node-gyp.js
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/bin/node-gyp.js
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/bin/node-gyp.js
-@@ -1,4 +1,4 @@
--#!/usr/bin/env node
-+#!/usr/bin/node8
- 
- /**
-  * Set the title.
 Index: node-v8.11.2/deps/npm/node_modules/npm-lifecycle/node-gyp-bin/node-gyp
 ===================================================================
 --- node-v8.11.2.orig/deps/npm/node_modules/npm-lifecycle/node-gyp-bin/node-gyp
@@ -422,41 +57,22 @@ Index: node-v8.11.2/deps/npm/node_modules/npm-lifecycle/node-gyp-bin/node-gyp
  if [ "x$npm_config_node_gyp" = "x" ]; then
    node "`dirname "$0"`/../../node_modules/node-gyp/bin/node-gyp.js" "$@"
  else
-Index: node-v8.11.2/deps/npm/node_modules/JSONStream/index.js
+Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/prepare-tests
 ===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/JSONStream/index.js
-+++ node-v8.11.2/deps/npm/node_modules/JSONStream/index.js
-@@ -1,5 +1,3 @@
--#! /usr/bin/env node
--
- 'use strict'
+--- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/prepare-tests
++++ node-v8.11.2/deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/prepare-tests
+@@ -1,4 +1,4 @@
+-#!/usr/bin/env sh
++#!/bin/sh
  
- var Parser = require('jsonparse')
-Index: node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py
-===================================================================
---- node-v8.11.2.orig/deps/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py
-+++ node-v8.11.2/deps/npm/node_modules/node-gyp/gyp/buildbot/buildbot_run.py
-@@ -1,4 +1,3 @@
--#!/usr/bin/env python
- # Copyright (c) 2012 Google Inc. All rights reserved.
- # Use of this source code is governed by a BSD-style license that can be
- # found in the LICENSE file.
-Index: node-v8.11.2/deps/npm/configure
-===================================================================
---- node-v8.11.2.orig/deps/npm/configure
-+++ node-v8.11.2/deps/npm/configure
-@@ -1,5 +1,3 @@
--#!/bin/bash
--
- # set configurations that will be "sticky" on this system,
- # surviving npm self-updates.
+ set -e
  
-Index: node-v8.11.2/deps/npm/lib/utils/completion.sh
+Index: node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash/etc/dashdash.bash_completion.in
 ===================================================================
---- node-v8.11.2.orig/deps/npm/lib/utils/completion.sh
-+++ node-v8.11.2/deps/npm/lib/utils/completion.sh
+--- node-v8.11.2.orig/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash/etc/dashdash.bash_completion.in
++++ node-v8.11.2/deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/node_modules/dashdash/etc/dashdash.bash_completion.in
 @@ -1,4 +1,3 @@
 -#!/bin/bash
- ###-begin-npm-completion-###
  #
- # npm command completion script
+ # Bash completion generated for '{{name}}' at {{date}}.
+ #

--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -323,6 +323,12 @@ echo "`grep node-v%{version}.tar.xz %{S:1} | head -n1 | cut -c1-64`  %{S:0}" | s
 # abnormalities from patching
 find -name configure.js.orig -delete
 
+# normalize shebang
+find -name \*.py -perm -1 -type f | xargs sed -i 's,^#!/usr/bin/env python,#!/usr/bin/python,'
+find -name \*.js -perm -1 -type f | xargs sed -i 's,^#!/usr/bin/env node,#!/usr/bin/node,; s,^#! /usr/bin/env node,#!/usr/bin/node,'
+sed -i 's,^#!/usr/bin/env node,#!/usr/bin/node,' deps/npm/node_modules/which/bin/which deps/npm/node_modules/uuid/bin/uuid deps/npm/node_modules/request/node_modules/http-signature/node_modules/sshpk/bin/sshpk-* deps/npm/node_modules/semver/bin/semver deps/npm/node_modules/node-gyp/node_modules/semver/bin/semver deps/npm/node_modules/request/node_modules/har-validator/node_modules/ajv/scripts/info
+find deps/npm/node_modules/request/node_modules/hawk -type f -exec chmod 0644 {} +
+
 %build
 # Make sure nothing gets included from bundled deps:
 # We only delete the source and header files, because
@@ -430,7 +436,6 @@ find %{buildroot}%{_libdir}/node_modules/npm%{node_version_number}/node_modules 
 find %{buildroot}%{_libdir}/node_modules/npm%{node_version_number}/node_modules -type d -name "benchmark" -print0 | xargs -0 rm -rf --
 
 # fix permissions
-find %{buildroot}%{_libdir}/node_modules -type f -exec chmod 0644 {} +
 chmod 0755 %{buildroot}%{_libdir}/node_modules/npm%{node_version_number}/bin/np*-cli.js
 chmod 0755 %{buildroot}%{_libdir}/node_modules/npm%{node_version_number}/bin/node-gyp-bin/node-gyp
 chmod 0755 %{buildroot}%{_libdir}/node_modules/npm%{node_version_number}/node_modules/node-gyp/bin/node-gyp.js


### PR DESCRIPTION
Update env_shebang.patch to keep most scripts executable
e.g. gyp_main.py is re-run by its generated Makefiles
but this only works if it is executable and has a shebang.