### PR TITLE
Use gcc7 on OpenSuSE 42.3 and higher

### DIFF
--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -174,7 +174,7 @@ BuildRequires:   gcc48-c++
 %endif # sles == 11
 
 # Use GCC 7, since it is in SLE-12:Update
-%if %node_version_number >= 8 && 0%{?suse_version} == 1315
+%if %node_version_number >= 8 && 0%{?suse_version} >= 120300
 BuildRequires:   gcc7-c++
 %define cc_exec  gcc-7
 %define cpp_exec g++-7

--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -173,8 +173,8 @@ BuildRequires:   gcc48-c++
 %endif # node >= 8
 %endif # sles == 11
 
-# Use GCC 7, since it is in SLE-12:Update
-%if %node_version_number >= 8 && 0%{?suse_version} >= 120300
+# Use GCC 7, since it is in SLE-12:Update (120300) or in Tumbleweed (1500)
+%if %node_version_number >= 8 && (0%{?sle_version} >= 120300 || 0%{?suse_version} > 1500)
 BuildRequires:   gcc7-c++
 %define cc_exec  gcc-7
 %define cpp_exec g++-7


### PR DESCRIPTION
Hi!

The gcc7 package is available from 42.3 onwards. This commit updates the version check as per version numbers in https://en.opensuse.org/openSUSE:Build_Service_cross_distribution_howto.

Package with this patch is live on https://build.opensuse.org/package/show/home:vjt:ifad/nodejs8.

Thank you,