### PR TITLE
Add _constraints for nodejs6 & nodejs8 to avoid "no space left on device" error

### DIFF
--- a/nodejs6/_constraints
+++ b/nodejs6/_constraints
@@ -1,0 +1,13 @@
+<constraints>
+  <overwrite>
+    <conditions>
+      <arch>ppc64le</arch>
+    </conditions>
+    <hardware>
+      <disk>
+        <size unit="G">4</size>
+      </disk>
+    </hardware>
+  </overwrite>
+</constraints>
+

--- a/nodejs6/nodejs6.changes
+++ b/nodejs6/nodejs6.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct  2 11:45:25 UTC 2019 - Michel Normand <normand@linux.vnet.ibm.com>
+
+- Add _constraints for ppc64le to avoid build error
+
+-------------------------------------------------------------------
 Mon Jul 29 09:01:36 UTC 2019 - Adam Majer <adam.majer@suse.de>
 
 - CVE-2019-13173.patch: fix potential file overwrite via hardlink

--- a/nodejs8/_constraints
+++ b/nodejs8/_constraints
@@ -1,0 +1,14 @@
+<constraints>
+  <overwrite>
+    <conditions>
+      <arch>aarch64</arch>
+      <arch>ppc64le</arch>
+    </conditions>
+    <hardware>
+      <disk>
+        <size unit="G">4</size>
+      </disk>
+    </hardware>
+  </overwrite>
+</constraints>
+

--- a/nodejs8/nodejs8.changes
+++ b/nodejs8/nodejs8.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Wed Oct  2 10:13:11 UTC 2019 - Michel Normand <normand@linux.vnet.ibm.com>
+
+- Add _constraints for aarch64 & ppc64le to avoid build error
+
+-------------------------------------------------------------------
 Wed Sep 18 13:44:55 UTC 2019 - Vítězslav Čížek <vcizek@suse.com>
 
 - Fix build with OpenSSL 1.1.1d (bsc#1149792)


### PR DESCRIPTION
Add _constraints for nodejs6 & nodejs8 to avoid "no space left on device" error

that concern ppc64le or aarch64

I do not know if sufficient commit in git but I verified in OBS in my own branch:
https://build.opensuse.org/package/show/home:michel_mno:branches:devel:languages:nodejs/nodejs6
https://build.opensuse.org/package/show/home:michel_mno:branches:devel:languages:nodejs/nodejs8