### PR TITLE
Fix ARM builds

### DIFF
--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -41,7 +41,16 @@ Release:        0
 %endif
 
 %bcond_with    valgrind_tests
+
+%if %{node_version_number} >= 12
 %bcond_without nodejs_lto
+%else
+%bcond_with nodejs_lto
+%endif
+
+%if !0%{?with nodejs_lto}
+%define _lto_cflags %{nil}
+%endif
 
 %if 0%{?suse_version} == 1110
 %define _libexecdir %{_exec_prefix}/lib
@@ -431,7 +440,7 @@ export CXX=%{?cpp_exec}
 
 ./configure \
     --prefix=%{_prefix} \
-%if 0%{?with nodejs_lto} && %{node_version_number} >= 12
+%if 0%{?with nodejs_lto}
     --enable-lto \
 %endif
 %if ! 0%{with intree_openssl}

--- a/nodejs10/nodejs10.changes
+++ b/nodejs10/nodejs10.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan  7 13:12:10 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Really disable LTO when required (nodejs < 12)
+
+-------------------------------------------------------------------
 Fri Dec 27 14:57:23 UTC 2019 - Adam Majer <adam.majer@suse.de>
 
 - node-gyp-addon-gypi.patch: Fix wrong path in gypi files (bsc#1159812)

--- a/nodejs12/nodejs12.changes
+++ b/nodejs12/nodejs12.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan  7 13:12:10 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Really disable LTO when required (nodejs < 12)
+
+-------------------------------------------------------------------
 Thu Dec 19 13:56:54 UTC 2019 - Adam Majer <adam.majer@suse.de>
 
 - Update to LTS release 12.14.0:

--- a/nodejs13/nodejs13.changes
+++ b/nodejs13/nodejs13.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan  7 13:12:10 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Really disable LTO when required (nodejs < 12)
+
+-------------------------------------------------------------------
 Fri Jan  3 15:03:17 UTC 2020 - Adam Majer <adam.majer@suse.de>
 
 - sle12_python3_compat.patch: Adds Python 3.4 to compatible

--- a/nodejs4/nodejs4.changes
+++ b/nodejs4/nodejs4.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan  7 13:12:10 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Really disable LTO when required (nodejs < 12)
+
+-------------------------------------------------------------------
 Mon Jul 29 09:01:42 UTC 2019 - Adam Majer <adam.majer@suse.de>
 
 - CVE-2019-13173.patch: fix potential file overwrite via hardlink

--- a/nodejs6/nodejs6.changes
+++ b/nodejs6/nodejs6.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan  7 13:12:10 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Really disable LTO when required (nodejs < 12)
+
+-------------------------------------------------------------------
 Thu Jan  2 14:40:46 UTC 2020 - Adam Majer <adam.majer@suse.de>
 
 - Add npm.tar.xz - Update npm to 6.13.4 fixing an arbitrary path

--- a/nodejs8/_constraints
+++ b/nodejs8/_constraints
@@ -8,6 +8,9 @@
       <disk>
         <size unit="G">4</size>
       </disk>
+      <memory>
+        <size unit="G">4</size>
+      </memory
     </hardware>
   </overwrite>
 </constraints>

--- a/nodejs8/nodejs8.changes
+++ b/nodejs8/nodejs8.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan  7 13:20:06 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Update _constraints for aarch64
+
+-------------------------------------------------------------------
 Tue Jan  7 13:12:10 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
 
 - Really disable LTO when required (nodejs < 12)

--- a/nodejs8/nodejs8.changes
+++ b/nodejs8/nodejs8.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jan  7 13:12:10 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Really disable LTO when required (nodejs < 12)
+
+-------------------------------------------------------------------
 Thu Dec 19 11:30:13 UTC 2019 - Adam Majer <adam.majer@suse.de>
 
 - New upstream LTS release 8.17.0:


### PR DESCRIPTION
* `Really disable LTO when required (nodejs < 12)`: fixes armv6/7 builds
* `nodejs8: Update _constraints for aarch64`: Fix build on aarch64 when LTO is disabled
