### PR TITLE
Update _constraints nodejs8 for ppc64 (BE)

### DIFF
--- a/nodejs8/_constraints
+++ b/nodejs8/_constraints
@@ -3,6 +3,7 @@
     <conditions>
       <arch>aarch64</arch>
       <arch>ppc64le</arch>
+      <arch>ppc64</arch>
     </conditions>
     <hardware>
       <disk>

--- a/nodejs8/nodejs8.changes
+++ b/nodejs8/nodejs8.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Apr  7 11:26:00 UTC 2020 - Michel Normand <normand@linux.vnet.ibm.com>
+
+- Update _constraints for ppc64 (BE)
+
+-------------------------------------------------------------------
 Fri Feb  7 14:54:56 UTC 2020 - Adam Majer <adam.majer@suse.de>
 
 - CVE-2019-15604.patch: fixes a remotely triggerable assertion


### PR DESCRIPTION
Added to avoid build failure on power8:05 memory limited to
3584MB.

Signed-off-by: Michel Normand <normand@linux.vnet.ibm.com>