### PR TITLE
Use GCC9 on aarch64 TW for nodejs<14- boo#1172686

### DIFF
--- a/nodejs-common/nodejs-common.changes
+++ b/nodejs-common/nodejs-common.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jul  7 08:33:00 UTC 2020 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Use GCC9 on aarch64 TW for nodejs<14- boo#1172686
+
+-------------------------------------------------------------------
 Tue Jun  9 10:35:06 UTC 2020 - Adam Majer <adam.majer@suse.de>
 
 - Add nodejs-default, npm-default and nodejs-devel-default subpackages

--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -223,6 +223,17 @@ BuildRequires:   gcc7-c++
 %endif
 %endif
 %endif
+
+# boo#1172686 - Build problems with gcc10 on aarch64
+%if 0%{?suse_version} > 1500
+%ifarch aarch64
+%if %node_version_number < 14
+BuildRequires:  gcc9-c++
+%define cc_exec  gcc-9
+%define cpp_exec g++-9
+%endif
+%endif
+%endif
 # compiler selection
 
 # No special version defined, use default.


### PR DESCRIPTION
Related to https://bugzilla.suse.com/show_bug.cgi?id=1172686