### PR TITLE
Remove trailing tokens after if/else/endif

### DIFF
--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -35,7 +35,7 @@ Release:        0
 %else
 %if %node_version_number >= 10
 %define openssl_req_ver 1.1.0
-%else # node8 or older
+%else
 %define openssl_req_ver 1.0.2
 %endif
 %endif
@@ -93,7 +93,7 @@ Release:        0
 %else
 %bcond_with    binutils_gold
 %endif
-%endif # aarch64
+%endif
 
 # No binutils_gold on all versions of SLE 12 and Leap 42 (s390x).
 %ifarch s390x
@@ -102,7 +102,7 @@ Release:        0
 %else
 %bcond_with    binutils_gold
 %endif
-%endif # s390x
+%endif
 
 %ifarch s390
 %bcond_with    binutils_gold
@@ -245,7 +245,7 @@ BuildRequires:  python2
 %else
 BuildRequires:  python
 %endif
-%endif  # python3
+%endif
 
 %if 0%{?suse_version} >= 1500 && %{node_version_number} >= 10
 BuildRequires:  user(nobody)
@@ -256,7 +256,7 @@ BuildRequires:  group(nobody)
 
 %if %node_version_number >= 8
 BuildRequires:  pkgconfig(openssl) >= %{openssl_req_ver}
-%else # older node doesn't support OpenSSL 1.1
+%else
 
 %if 0%{?suse_version} >= 1330
 BuildRequires:  libopenssl-1_0_0-devel
@@ -264,8 +264,8 @@ BuildRequires:  libopenssl-1_0_0-devel
 BuildRequires:  openssl-devel >= %{openssl_req_ver}
 %endif
 
-%endif # older node doesn't support OpenSSL 1.1
-%endif # ! {with intree_openssl}
+%endif
+%endif
 
 %if ! 0%{with intree_cares}
 BuildRequires:  pkgconfig(libcares) >= {{min_libcares2_version}}
@@ -379,7 +379,7 @@ tar Jxvf %{SOURCE10}
 
 %if %{node_version_number} >= 10
 tar Jxvf %{SOURCE11}
-%endif # node_version_number
+%endif
 
 %patch1 -p1
 %patch3 -p1

--- a/nodejs14/nodejs14.changes
+++ b/nodejs14/nodejs14.changes
@@ -1,4 +1,9 @@
 -------------------------------------------------------------------
+Tue Jul 28 07:13:57 UTC 2020 - Dirk Mueller <dmueller@suse.com>
+
+- avoid rpmbuild warnings on if/else/endif constructs
+
+-------------------------------------------------------------------
 Thu Jul  2 20:51:30 UTC 2020 - Adam Majer <adam.majer@suse.de>
 
 - Update to version 14.5.0:


### PR DESCRIPTION
The newer rpm version in openSUSE Tumbleweed considers those a build
warning, so avoid it.