### PR TITLE
Double memory limits for dwz.

### DIFF
--- a/nodejs.spec.in
+++ b/nodejs.spec.in
@@ -28,6 +28,10 @@ Name:           nodejs{{node_version_major}}
 Version:        {{node_version}}
 Release:        0
 
+# Double DWZ memory limits
+%define _dwz_low_mem_die_limit  20000000
+%define _dwz_max_die_limit     100000000
+
 %define node_version_number {{node_version_major}}
 
 %if %node_version_number >= 12


### PR DESCRIPTION
In order to handle:
dwz: ./usr/bin/node15-15.11.0-2.2.x86_64.debug: Too many DIEs, not optimizing