### PR TITLE
nodejs19: Update _constraints for Arm

### DIFF
--- a/nodejs19/nodejs19.changes
+++ b/nodejs19/nodejs19.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Fri Dec 23 11:31:12 UTC 2022 - Guillaume GARDET <guillaume.gardet@opensuse.org>
+
+- Update _constraints:
+  * Less RAM for aarch64 and 32-bit arm
+  * Use 'asimdrdm' cpu flag to use aarch64 workers where tests
+    are more stable
+
+-------------------------------------------------------------------
 Mon Nov  7 14:00:54 UTC 2022 - Adam Majer <adam.majer@suse.de>
 
 - Fix migration to openssl-3 (bsc#1205042)

--- a/staging-master/_constraints
+++ b/staging-master/_constraints
@@ -8,4 +8,28 @@
     <size unit="M">10000</size>
    </physicalmemory>
   </hardware>
+  <overwrite>
+    <conditions>
+      <arch>aarch64</arch>
+    </conditions>
+    <hardware>
+      <cpu>
+        <flag>asimdrdm</flag>
+      </cpu>
+      <physicalmemory>
+        <size unit="G">6</size>
+      </physicalmemory>
+    </hardware>
+  </overwrite>
+  <overwrite>
+    <conditions>
+      <arch>armv6l</arch>
+      <arch>armv7l</arch>
+    </conditions>
+    <hardware>
+      <physicalmemory>
+        <size unit="G">5</size>
+      </physicalmemory>
+    </hardware>
+  </overwrite>
 </constraints>


### PR DESCRIPTION
Update _constraints:
  * Less RAM for aarch64 and 32-bit arm
  * Use 'asimdrdm' cpu flag to use aarch64 workers where tests are more stable